### PR TITLE
Label some Brinstar enemy animations, fixes

### DIFF
--- a/SRC/brinstar/enemy_sprite_data.asm
+++ b/SRC/brinstar/enemy_sprite_data.asm
@@ -4,20 +4,24 @@ EnAnimTbl: ;($9D6A)
 EnAnim_00:
     .byte _id_EnFrame00, _id_EnFrame01, $FF
 
-EnAnim_03:
+EnAnim_FireballKilled:
     .byte _id_EnFrame02, $FF
 
 EnAnim_05:
     .byte _id_EnFrame19, _id_EnFrame1A, $FF
 
 EnAnim_08:
-    .byte _id_EnFrame1A, _id_EnFrame1B, $FF
+    .byte _id_EnFrame1A
+EnAnim_09:
+    .byte _id_EnFrame1B, $FF
 
 EnAnim_0B:
     .byte _id_EnFrame1C, _id_EnFrame1D, $FF
 
 EnAnim_0E:
-    .byte _id_EnFrame1D, _id_EnFrame1E, $FF
+    .byte _id_EnFrame1D
+EnAnim_0F:
+    .byte _id_EnFrame1E, $FF
 
 EnAnim_11:
     .byte _id_EnFrame22, _id_EnFrame23
@@ -29,19 +33,23 @@ EnAnim_15:
 EnAnim_17:
     .byte _id_EnFrame21, $FF
 
-EnAnim_19:
+EnAnim_RipperFacingLeft:
     .byte _id_EnFrame22, $FF
 
-EnAnim_1B:
+EnAnim_RipperFacingRight:
     .byte _id_EnFrame1F, $FF
 
 EnAnim_1D:
-    .byte _id_EnFrame23, _id_EnFrame04, $FF
+    .byte _id_EnFrame23,
+EnAnim_1E:
+    .byte _id_EnFrame04, $FF
 
 EnAnim_20:
-    .byte _id_EnFrame20, _id_EnFrame03, $FF
+    .byte _id_EnFrame20
+EnAnim_21:
+    .byte _id_EnFrame03, $FF
 
-EnAnim_23:
+EnAnim_Skree:
     .byte _id_EnFrame27, _id_EnFrame28, _id_EnFrame29, $FF
 
 EnAnim_27:
@@ -56,49 +64,49 @@ EnAnim_2B:
 EnAnim_2D:
     .byte _id_EnFrame3A, $FF
 
-EnAnim_2F:
+EnAnim_RipperExplodeFacingLeft:
     .byte _id_EnFrame3B, $FF
 
-EnAnim_31:
+EnAnim_RipperExplodeFacingRight:
     .byte _id_EnFrame3C, $FF
 
-EnAnim_33:
+EnAnim_SkreeExplode:
     .byte _id_EnFrame3D, $FF
 
-EnAnim_35:
+EnAnim_ZoomerOnFloor:
     .byte _id_EnFrame58, _id_EnFrame59, $FF
 
-EnAnim_38:
+EnAnim_ZoomerOnRightWall:
     .byte _id_EnFrame5A, _id_EnFrame5B, $FF
 
-EnAnim_3B:
+EnAnim_ZoomerOnCeiling:
     .byte _id_EnFrame5C, _id_EnFrame5D, $FF
 
-EnAnim_3E:
+EnAnim_ZoomerOnLeftWall:
     .byte _id_EnFrame5E, _id_EnFrame5F, $FF
 
-EnAnim_41:
+EnAnim_ZoomerExplode:
     .byte _id_EnFrame60, $FF
 
-EnAnim_43:
+EnAnim_Explosion:
     .byte _id_EnFrame61, $F7, _id_EnFrame62, $F7, $FF
 
-EnAnim_48:
+EnAnim_Rio:
     .byte _id_EnFrame63, _id_EnFrame64, $FF
 
-EnAnim_4B:
+EnAnim_RioExplode:
     .byte _id_EnFrame65, $FF
 
-EnAnim_4D:
+EnAnim_ZebFacingLeft:
     .byte _id_EnFrame66, _id_EnFrame67, $FF
 
-EnAnim_50:
+EnAnim_ZebFacingRight:
     .byte _id_EnFrame69, _id_EnFrame6A, $FF
 
-EnAnim_53:
+EnAnim_ZebExplodeFacingLeft:
     .byte _id_EnFrame68, $FF
 
-EnAnim_55:
+EnAnim_ZebExplodeFacingRight:
     .byte _id_EnFrame6B, $FF
 
 EnAnim_57:
@@ -123,7 +131,7 @@ EnAnim_64:
 EnAnim_67:
     .byte _id_EnFrame72, $FF
 
-EnAnim_69:
+EnAnim_Mellow:
     .byte _id_EnFrame8F, _id_EnFrame90, $FF
 
 EnAnim_6C:
@@ -357,6 +365,7 @@ EnPlaceF:
 
 ;Enemy frame drawing data.
 
+;Unused.
 EnFrame00:
     .byte ($0 << 4) + _id_EnPlace0, $02, $02
     .byte $14
@@ -367,6 +376,7 @@ EnFrame01:
     .byte $24
     .byte $FF
 
+;Fireball killed.
 EnFrame02:
     .byte ($0 << 4) + _id_EnPlace0, $00, $00
     .byte $04
@@ -480,6 +490,7 @@ EnFrame1E:
     .byte $B3
     .byte $FF
 
+;Ripper facing right.
 EnFrame1F:
     .byte ($2 << 4) + _id_EnPlace7, $06, $08
     .byte $FC, $04, $00
@@ -505,6 +516,7 @@ EnFrame21:
     .byte $F1
     .byte $FF
 
+;Ripper facing left.
 EnFrame22:
     .byte OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $06, $08
     .byte $FC, $04, $00
@@ -530,6 +542,7 @@ EnFrame24:
     .byte $F1
     .byte $FF
 
+;Skree.
 EnFrame25:
 EnFrame26:
 EnFrame27:
@@ -543,6 +556,7 @@ EnFrame27:
     .byte $EE
     .byte $FF
 
+;Skree.
 EnFrame28:
     .byte ($2 << 4) + _id_EnPlace8, $0C, $08
     .byte $CE
@@ -550,6 +564,7 @@ EnFrame28:
     .byte $EF
     .byte $FF
 
+;Skree.
 EnFrame29:
     .byte ($2 << 4) + _id_EnPlace8, $0C, $08
     .byte $CE
@@ -613,6 +628,7 @@ EnFrame3A:
     .byte $F1
     .byte $FF
 
+;Ripper explode facing left (uses waver gfx).
 EnFrame3B:
     .byte ($2 << 4) + _id_EnPlace1, $00, $00
     .byte $FC, $08, $00
@@ -620,6 +636,7 @@ EnFrame3B:
     .byte $D0
     .byte $FF
 
+;Ripper explode facing right (uses waver gfx).
 EnFrame3C:
     .byte ($2 << 4) + _id_EnPlace1, $00, $00
     .byte $FC, $08, $00
@@ -627,6 +644,7 @@ EnFrame3C:
     .byte $D1
     .byte $FF
 
+;Skree explode.
 EnFrame3D:
     .byte ($2 << 4) + _id_EnPlace1, $00, $00
     .byte $FC, $08, $00
@@ -636,6 +654,7 @@ EnFrame3D:
     .byte $EE
     .byte $FF
 
+;Zoomer on floor.
 EnFrame3E:
 EnFrame3F:
 EnFrame40:
@@ -670,6 +689,7 @@ EnFrame58:
     .byte $DD
     .byte $FF
 
+;Zoomer on floor.
 EnFrame59:
     .byte OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CC
@@ -678,6 +698,7 @@ EnFrame59:
     .byte $DD
     .byte $FF
 
+;Zoomer on right wall.
 EnFrame5A:
     .byte ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -686,6 +707,7 @@ EnFrame5A:
     .byte $DB
     .byte $FF
 
+;Zoomer on right wall.
 EnFrame5B:
     .byte OAMDATA_VFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -694,6 +716,7 @@ EnFrame5B:
     .byte $DB
     .byte $FF
 
+;Zoomer on ceiling.
 EnFrame5C:
     .byte OAMDATA_VFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CC
@@ -702,6 +725,7 @@ EnFrame5C:
     .byte $DD
     .byte $FF
 
+;Zoomer on ceiling.
 EnFrame5D:
     .byte OAMDATA_VFLIP + OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CC
@@ -710,6 +734,7 @@ EnFrame5D:
     .byte $DD
     .byte $FF
 
+;Zoomer on left wall.
 EnFrame5E:
     .byte OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -718,6 +743,7 @@ EnFrame5E:
     .byte $DB
     .byte $FF
 
+;Zoomer on left wall.
 EnFrame5F:
     .byte OAMDATA_VFLIP + OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -726,6 +752,7 @@ EnFrame5F:
     .byte $DB
     .byte $FF
 
+;Zoomer explode.
 EnFrame60:
     .byte ($2 << 4) + _id_EnPlace1, $00, $00
     .byte $CC
@@ -734,6 +761,7 @@ EnFrame60:
     .byte $DD
     .byte $FF
 
+;Explosion.
 EnFrame61:
     .byte ($0 << 4) + _id_EnPlaceA, $00, $00
     .byte $75
@@ -745,6 +773,7 @@ EnFrame61:
     .byte $75
     .byte $FF
 
+;Explosion.
 EnFrame62:
     .byte ($0 << 4) + _id_EnPlaceA, $00, $00
     .byte $FE
@@ -768,6 +797,7 @@ EnFrame62:
     .byte $3E
     .byte $FF
 
+;Rio.
 EnFrame63:
     .byte ($2 << 4) + _id_EnPlaceB, $08, $08
     .byte $E2
@@ -779,6 +809,7 @@ EnFrame63:
     .byte $E4
     .byte $FF
 
+;Rio.
 EnFrame64:
     .byte ($2 << 4) + _id_EnPlaceB, $08, $08
     .byte $E2
@@ -791,6 +822,7 @@ EnFrame64:
     .byte $E4
     .byte $FF
 
+;Rio explode (gfx looks wrong).
 EnFrame65:
     .byte ($2 << 4) + _id_EnPlace1, $00, $00
     .byte $96
@@ -907,6 +939,7 @@ EnFrame75:
     .byte $D8
     .byte $FF
 
+;Missile pickup.
 EnFrame76:
 EnFrame77:
 EnFrame78:
@@ -925,11 +958,13 @@ EnFrame80:
     .byte $24
     .byte $FF
 
+;Small energy pickup.
 EnFrame81:
     .byte ($0 << 4) + _id_EnPlace0, $04, $04
     .byte $8A
     .byte $FF
 
+;Big energy pickup.
 EnFrame82:
 EnFrame83:
 EnFrame84:
@@ -942,6 +977,7 @@ EnFrame89:
     .byte $8A
     .byte $FF
 
+;Mellow.
 EnFrame8A:
 EnFrame8B:
 EnFrame8C:
@@ -955,6 +991,7 @@ EnFrame8F:
     .byte $EC
     .byte $FF
 
+;Mellow.
 EnFrame90:
     .byte ($3 << 4) + _id_EnPlaceF, $04, $08
     .byte $FD, $3

--- a/SRC/constants.asm
+++ b/SRC/constants.asm
@@ -907,7 +907,7 @@ EnSubPixelX            = $6AFD   ; Unknown
 EnAccelY               = $6AFE   ; Unknown
 EnAccelX               = $6AFF   ; Unknown
 EnData1C               = $6B00   ; Unknown
-EnData1D               = $6B01   ; Unknown
+EnData1D               = $6B01   ;Signed taxicab distance to wherever this variable was cleared; skree blow up delay
 EnType                 = $6B02   ;Enemy type used as index into enemy data tables.
 EnData1F               = $6B03   ; Unknown
 

--- a/SRC/enemies/crawler.asm
+++ b/SRC/enemies/crawler.asm
@@ -59,16 +59,16 @@ Crawler04:
     lda CrawlerAnimIndexTable,y
     jmp CommonJump_InitEnAnimIndex
 
-.if BANK == 1 || BANK == 4
+.if BANK == 1
     CrawlerAnimIndexTable:
-        .byte EnAnim_35 - EnAnimTbl
-        .byte EnAnim_35 - EnAnimTbl
-        .byte EnAnim_3E - EnAnimTbl
-        .byte EnAnim_38 - EnAnimTbl
-        .byte EnAnim_3B - EnAnimTbl
-        .byte EnAnim_3B - EnAnimTbl
-        .byte EnAnim_38 - EnAnimTbl
-        .byte EnAnim_3E - EnAnimTbl
+        .byte EnAnim_ZoomerOnFloor - EnAnimTbl
+        .byte EnAnim_ZoomerOnFloor - EnAnimTbl
+        .byte EnAnim_ZoomerOnLeftWall - EnAnimTbl
+        .byte EnAnim_ZoomerOnRightWall - EnAnimTbl
+        .byte EnAnim_ZoomerOnCeiling - EnAnimTbl
+        .byte EnAnim_ZoomerOnCeiling - EnAnimTbl
+        .byte EnAnim_ZoomerOnRightWall - EnAnimTbl
+        .byte EnAnim_ZoomerOnLeftWall - EnAnimTbl
 .elif BANK == 2
     CrawlerAnimIndexTable:
         .byte EnAnim_69 - EnAnimTbl
@@ -79,6 +79,16 @@ Crawler04:
         .byte EnAnim_6F - EnAnimTbl
         .byte EnAnim_6C - EnAnimTbl
         .byte EnAnim_72 - EnAnimTbl
+.elif BANK == 4
+    CrawlerAnimIndexTable:
+        .byte EnAnim_ZeelaOnFloor - EnAnimTbl
+        .byte EnAnim_ZeelaOnFloor - EnAnimTbl
+        .byte EnAnim_ZeelaOnLeftWall - EnAnimTbl
+        .byte EnAnim_ZeelaOnRightWall - EnAnimTbl
+        .byte EnAnim_ZeelaOnCeiling - EnAnimTbl
+        .byte EnAnim_ZeelaOnCeiling - EnAnimTbl
+        .byte EnAnim_ZeelaOnRightWall - EnAnimTbl
+        .byte EnAnim_ZeelaOnLeftWall - EnAnimTbl
 .elif BANK == 5
     CrawlerAnimIndexTable:
         .byte EnAnim_4A - EnAnimTbl

--- a/SRC/enemies/metroid.asm
+++ b/SRC/enemies/metroid.asm
@@ -99,7 +99,7 @@ MetroidAIRoutine:
     
     ; check if metroid is frozen or not
     lda EnStatus,x
-    cmp #$04
+    cmp #enemyStatus_Frozen
     bne L9894
         ; metroid is frozen
         ; check if metroid was invincible

--- a/SRC/enemies/ridley.asm
+++ b/SRC/enemies/ridley.asm
@@ -18,9 +18,9 @@ RidleyBranch_Explode:
     beq RidleyBranch_Exit
 
 RidleyBranch_Normal:
-    lda #$0B
+    lda #EnAnim_0B - EnAnimTbl.b
     sta EnemyLFB88_85
-    lda #$0E
+    lda #EnAnim_0E - EnAnimTbl.b
     sta EnemyLFB88_85+1.b
     jsr CommonJump_09
     jsr RidleyTryToLaunchProjectile

--- a/SRC/enemies/seahorse.asm
+++ b/SRC/enemies/seahorse.asm
@@ -53,7 +53,7 @@ SeahorseAIRoutine:
 
 L9B4F:
     lda EnStatus,x
-    cmp #$03
+    cmp #enemyStatus_Explode
     beq L9B59
     jsr CommonJump_0A
 L9B59:

--- a/SRC/enemies/sidehopper.asm
+++ b/SRC/enemies/sidehopper.asm
@@ -2,15 +2,15 @@
 ; Bank 5 is Dessgeega
 SidehopperFloorAIRoutine:
     .if BANK == 1 || BANK == 4
-        lda #$09
+        lda #EnAnim_09 - EnAnimTbl.b
     .elif BANK == 5
-        lda #$42
+        lda #EnAnim_42 - EnAnimTbl.b
     .endif
 Sidehopper_Common:
     sta EnemyLFB88_85
     sta EnemyLFB88_85+1.b
     lda EnStatus,x
-    cmp #$03
+    cmp #enemyStatus_Explode
     beq CommonEnemyStub2
         jsr CommonJump_09
 CommonEnemyStub2:
@@ -24,8 +24,8 @@ CommonEnemyStub:
 ; Ceiling Sidehopper Routine
 SidehopperCeilingAIRoutine:
     .if BANK == 1 || BANK == 4
-        lda #$0F
+        lda #EnAnim_0F - EnAnimTbl.b
     .elif BANK == 5
-        lda #$48
+        lda #EnAnim_48 - EnAnimTbl.b
     .endif
     jmp Sidehopper_Common

--- a/SRC/enemies/squeept.asm
+++ b/SRC/enemies/squeept.asm
@@ -4,9 +4,9 @@ SqueeptAIRoutine:
     cmp #enemyStatus_Resting
     bne L9A88
     lda EnStatus,x
-    cmp #$03
+    cmp #enemyStatus_Explode
     beq L9ACA
-    cmp #$02
+    cmp #enemyStatus_Active
     bne L9A88
     ldy EnMovementIndex,x
     lda L9AD2,y

--- a/SRC/enemies/swooper.asm
+++ b/SRC/enemies/swooper.asm
@@ -5,7 +5,7 @@ SwooperAIRoutine:
     lda #$08
     sta $01
     lda EnStatus,x
-    cmp #$01
+    cmp #enemyStatus_Resting
     bne L98EE
     lda EnData05,x
     and #$10
@@ -17,19 +17,19 @@ L98EE:
     jmp CommonEnemyJump_00_01_02
 L98F4:
     lda EnStatus,x
-    cmp #$02
+    cmp #enemyStatus_Active
     bne L9907
     .if BANK == 2
-        lda #$25
+        lda #EnAnim_25 - EnAnimTbl.b
     .elif BANK == 5
-        lda #$20
+        lda #EnAnim_20 - EnAnimTbl.b
     .endif
     ldy EnSpeedY,x
     bpl L9904
         .if BANK == 2
-            lda #$22
+            lda #EnAnim_22 - EnAnimTbl.b
         .elif BANK == 5
-            lda #$1D
+            lda #EnAnim_1D - EnAnimTbl.b
         .endif
     L9904:
     sta EnResetAnimIndex,x
@@ -45,7 +45,7 @@ SwooperAIRoutine2:
         cmp #$03
         beq SwooperExitB
         lda EnStatus,x
-        cmp #$01
+        cmp #enemyStatus_Resting
         bne L9923
         lda #$00
         jsr L9954

--- a/SRC/enemies/waver.asm
+++ b/SRC/enemies/waver.asm
@@ -1,8 +1,8 @@
 ; Waver Routine
 WaverAIRoutine:
-    lda #$21
+    lda #EnAnim_21 - EnAnimTbl.b
     sta EnemyLFB88_85
-    lda #$1E
+    lda #EnAnim_1E - EnAnimTbl.b
     sta EnemyLFB88_85+1.b
     lda EnStatus,x
     cmp #enemyStatus_Explode

--- a/SRC/kraid/enemy_sprite_data.asm
+++ b/SRC/kraid/enemy_sprite_data.asm
@@ -4,20 +4,24 @@ EnAnimTbl: ;($9C86)
 EnAnim_00:
     .byte _id_EnFrame00, _id_EnFrame01, $FF
 
-EnAnim_03:
+EnAnim_FireballKilled:
     .byte _id_EnFrame02, $FF
 
 EnAnim_05:
     .byte _id_EnFrame19, _id_EnFrame1A, $FF
 
 EnAnim_08:
-    .byte _id_EnFrame1A, _id_EnFrame1B, $FF
+    .byte _id_EnFrame1A
+EnAnim_09:
+    .byte _id_EnFrame1B, $FF
 
 EnAnim_0B:
     .byte _id_EnFrame1C, _id_EnFrame1D, $FF
 
 EnAnim_0E:
-    .byte _id_EnFrame1D, _id_EnFrame1E, $FF
+    .byte _id_EnFrame1D
+EnAnim_0F:
+    .byte _id_EnFrame1E, $FF
 
 EnAnim_11:
     .byte _id_EnFrame22, _id_EnFrame23
@@ -65,16 +69,16 @@ EnAnim_31:
 EnAnim_33:
     .byte _id_EnFrame3D, $FF
 
-EnAnim_35:
+EnAnim_ZeelaOnFloor:
     .byte _id_EnFrame58, _id_EnFrame59, $FF
 
-EnAnim_38:
+EnAnim_ZeelaOnRightWall:
     .byte _id_EnFrame5A, _id_EnFrame5B, $FF
 
-EnAnim_3B:
+EnAnim_ZeelaOnCeiling:
     .byte _id_EnFrame5C, _id_EnFrame5D, $FF
 
-EnAnim_3E:
+EnAnim_ZeelaOnLeftWall:
     .byte _id_EnFrame5E, _id_EnFrame5F, $FF
 
 EnAnim_41:
@@ -618,6 +622,7 @@ EnFrame3D:
     .byte $EE
     .byte $FF
 
+;Zeela on floor.
 EnFrame3E:
 EnFrame3F:
 EnFrame40:
@@ -652,6 +657,7 @@ EnFrame58:
     .byte $DD
     .byte $FF
 
+;Zeela on floor.
 EnFrame59:
     .byte OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CC
@@ -660,6 +666,7 @@ EnFrame59:
     .byte $DD
     .byte $FF
 
+;Zeela on right wall.
 EnFrame5A:
     .byte ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -668,6 +675,7 @@ EnFrame5A:
     .byte $DB
     .byte $FF
 
+;Zeela on right wall.
 EnFrame5B:
     .byte OAMDATA_VFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -676,6 +684,7 @@ EnFrame5B:
     .byte $DB
     .byte $FF
 
+;Zeela on ceiling.
 EnFrame5C:
     .byte OAMDATA_VFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CC
@@ -684,6 +693,7 @@ EnFrame5C:
     .byte $DD
     .byte $FF
 
+;Zeela on ceiling.
 EnFrame5D:
     .byte OAMDATA_VFLIP + OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CC
@@ -692,6 +702,7 @@ EnFrame5D:
     .byte $DD
     .byte $FF
 
+;Zeela on left wall.
 EnFrame5E:
     .byte OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -700,6 +711,7 @@ EnFrame5E:
     .byte $DB
     .byte $FF
 
+;Zeela on left wall.
 EnFrame5F:
     .byte OAMDATA_VFLIP + OAMDATA_HFLIP + ($2 << 4) + _id_EnPlace7, $08, $08
     .byte $CA
@@ -708,6 +720,7 @@ EnFrame5F:
     .byte $DB
     .byte $FF
 
+;Zeela explode.
 EnFrame60:
     .byte ($2 << 4) + _id_EnPlace1, $00, $00
     .byte $CC

--- a/SRC/norfair/enemy_sprite_data.asm
+++ b/SRC/norfair/enemy_sprite_data.asm
@@ -4,7 +4,7 @@ EnAnimTbl: ;($9BDA)
 EnAnim_00:
     .byte _id_EnFrame00, _id_EnFrame01, $FF
 
-EnAnim_03:
+EnAnim_FireballKilled:
     .byte _id_EnFrame02, $FF
 
 EnAnim_05:

--- a/SRC/prg1_brinstar.asm
+++ b/SRC/prg1_brinstar.asm
@@ -119,9 +119,9 @@ AreaPalToggle:
 
     .byte $00
 AreaFireballKilledAnimIndex:
-    .byte EnAnim_03 - EnAnimTbl
+    .byte EnAnim_FireballKilled - EnAnimTbl
 AreaExplosionAnimIndex:
-    .byte EnAnim_43 - EnAnimTbl
+    .byte EnAnim_Explosion - EnAnimTbl
 
     .byte $00, $00
 AreaFireballFallingAnimIndex:
@@ -129,7 +129,7 @@ AreaFireballFallingAnimIndex:
 AreaFireballSplatterAnimIndex:
     .byte $00, $00
 AreaMellowAnimIndex:
-    .byte EnAnim_69 - EnAnimTbl
+    .byte EnAnim_Mellow - EnAnimTbl
 
 ; Enemy AI jump table
 ChooseEnemyAIRoutine:
@@ -157,16 +157,16 @@ EnemyDeathAnimIndex:
     .byte EnAnim_27 - EnAnimTbl, EnAnim_27 - EnAnimTbl
     .byte EnAnim_29 - EnAnimTbl, EnAnim_29 - EnAnimTbl
     .byte EnAnim_2D - EnAnimTbl, EnAnim_2B - EnAnimTbl
-    .byte EnAnim_31 - EnAnimTbl, EnAnim_2F - EnAnimTbl
-    .byte EnAnim_33 - EnAnimTbl, EnAnim_33 - EnAnimTbl
-    .byte EnAnim_41 - EnAnimTbl, EnAnim_41 - EnAnimTbl
-    .byte EnAnim_4B - EnAnimTbl, EnAnim_4B - EnAnimTbl
-    .byte EnAnim_55 - EnAnimTbl, EnAnim_53 - EnAnimTbl
+    .byte EnAnim_RipperExplodeFacingRight - EnAnimTbl, EnAnim_RipperExplodeFacingLeft - EnAnimTbl
+    .byte EnAnim_SkreeExplode - EnAnimTbl, EnAnim_SkreeExplode - EnAnimTbl
+    .byte EnAnim_ZoomerExplode - EnAnimTbl, EnAnim_ZoomerExplode - EnAnimTbl
+    .byte EnAnim_RioExplode - EnAnimTbl, EnAnim_RioExplode - EnAnimTbl
+    .byte EnAnim_ZebExplodeFacingRight - EnAnimTbl, EnAnim_ZebExplodeFacingLeft - EnAnimTbl
     .byte EnAnim_72 - EnAnimTbl, EnAnim_74 - EnAnimTbl ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl ; unused enemy
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl ; unused enemy
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl ; unused enemy
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
@@ -179,16 +179,16 @@ EnemyRestingAnimIndex:
     .byte EnAnim_05 - EnAnimTbl, EnAnim_05 - EnAnimTbl
     .byte EnAnim_0B - EnAnimTbl, EnAnim_0B - EnAnimTbl
     .byte EnAnim_17 - EnAnimTbl, EnAnim_13 - EnAnimTbl
-    .byte EnAnim_1B - EnAnimTbl, EnAnim_19 - EnAnimTbl
-    .byte EnAnim_23 - EnAnimTbl, EnAnim_23 - EnAnimTbl
-    .byte EnAnim_35 - EnAnimTbl, EnAnim_35 - EnAnimTbl
-    .byte EnAnim_48 - EnAnimTbl, EnAnim_48 - EnAnimTbl
+    .byte EnAnim_RipperFacingRight - EnAnimTbl, EnAnim_RipperFacingLeft - EnAnimTbl
+    .byte EnAnim_Skree - EnAnimTbl, EnAnim_Skree - EnAnimTbl
+    .byte EnAnim_ZoomerOnFloor - EnAnimTbl, EnAnim_ZoomerOnFloor - EnAnimTbl
+    .byte EnAnim_Rio - EnAnimTbl, EnAnim_Rio - EnAnimTbl
     .byte EnAnim_59 - EnAnimTbl, EnAnim_57 - EnAnimTbl
     .byte EnAnim_6C - EnAnimTbl, EnAnim_6F - EnAnimTbl ; unused enemy
     .byte EnAnim_5B - EnAnimTbl, EnAnim_5D - EnAnimTbl ; unused enemy
     .byte EnAnim_62 - EnAnimTbl, EnAnim_67 - EnAnimTbl ; unused enemy
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl ; unused enemy
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl ; unused enemy
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl ; unused enemy
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
@@ -198,16 +198,16 @@ EnemyActiveAnimIndex:
     .byte EnAnim_05 - EnAnimTbl, EnAnim_05 - EnAnimTbl
     .byte EnAnim_0B - EnAnimTbl, EnAnim_0B - EnAnimTbl
     .byte EnAnim_17 - EnAnimTbl, EnAnim_13 - EnAnimTbl
-    .byte EnAnim_1B - EnAnimTbl, EnAnim_19 - EnAnimTbl
-    .byte EnAnim_23 - EnAnimTbl, EnAnim_23 - EnAnimTbl
-    .byte EnAnim_35 - EnAnimTbl, EnAnim_35 - EnAnimTbl
-    .byte EnAnim_48 - EnAnimTbl, EnAnim_48 - EnAnimTbl
-    .byte EnAnim_50 - EnAnimTbl, EnAnim_4D - EnAnimTbl
+    .byte EnAnim_RipperFacingRight - EnAnimTbl, EnAnim_RipperFacingLeft - EnAnimTbl
+    .byte EnAnim_Skree - EnAnimTbl, EnAnim_Skree - EnAnimTbl
+    .byte EnAnim_ZoomerOnFloor - EnAnimTbl, EnAnim_ZoomerOnFloor - EnAnimTbl
+    .byte EnAnim_Rio - EnAnimTbl, EnAnim_Rio - EnAnimTbl
+    .byte EnAnim_ZebFacingRight - EnAnimTbl, EnAnim_ZebFacingLeft - EnAnimTbl
     .byte EnAnim_6C - EnAnimTbl, EnAnim_6F - EnAnimTbl ; unused enemy
     .byte EnAnim_5B - EnAnimTbl, EnAnim_5D - EnAnimTbl ; unused enemy
     .byte EnAnim_5F - EnAnimTbl, EnAnim_64 - EnAnimTbl ; unused enemy
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl ; unused enemy
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl ; unused enemy
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl ; unused enemy
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
     .byte $00, $00 ; unused enemy
@@ -316,7 +316,7 @@ L977B:
 EnemyFireballRisingAnimIndexTable:
     .byte $00, $00
     .byte EnAnim_64 - EnAnimTbl, EnAnim_67 - EnAnimTbl
-    .byte EnAnim_69 - EnAnimTbl, EnAnim_69 - EnAnimTbl
+    .byte EnAnim_Mellow - EnAnimTbl, EnAnim_Mellow - EnAnimTbl
     .byte $00, $00
     .byte $00, $00
     .byte $00, $00

--- a/SRC/prg2_norfair.asm
+++ b/SRC/prg2_norfair.asm
@@ -122,7 +122,7 @@ AreaPalToggle:
 
     .byte $00
 AreaFireballKilledAnimIndex:
-    .byte EnAnim_03 - EnAnimTbl
+    .byte EnAnim_FireballKilled - EnAnimTbl
 AreaExplosionAnimIndex:
     .byte EnAnim_77 - EnAnimTbl
 ; fireball rising?

--- a/SRC/prg3_tourian.asm
+++ b/SRC/prg3_tourian.asm
@@ -128,7 +128,7 @@ AreaPalToggle:
 
     .byte $00
 AreaFireballAnimIndex:
-    .byte EnAnim_03 - EnAnimTbl
+    .byte EnAnim_FireballKilled - EnAnimTbl
 AreaExplosionAnimIndex:
     .byte EnAnim_21 - EnAnimTbl
 

--- a/SRC/prg4_kraid.asm
+++ b/SRC/prg4_kraid.asm
@@ -125,7 +125,7 @@ AreaPalToggle:
 
     .byte $00
 AreaFireballAnimIndex:
-    .byte EnAnim_03 - EnAnimTbl
+    .byte EnAnim_FireballKilled - EnAnimTbl
 AreaExplosionAnimIndex:
     .byte EnAnim_43 - EnAnimTbl
 
@@ -184,7 +184,7 @@ EnemyRestingAnimIndex:
     .byte EnAnim_17 - EnAnimTbl, EnAnim_13 - EnAnimTbl ; unused enemy
     .byte EnAnim_1B - EnAnimTbl, EnAnim_19 - EnAnimTbl
     .byte EnAnim_23 - EnAnimTbl, EnAnim_23 - EnAnimTbl
-    .byte EnAnim_35 - EnAnimTbl, EnAnim_35 - EnAnimTbl
+    .byte EnAnim_ZeelaOnFloor - EnAnimTbl, EnAnim_ZeelaOnFloor - EnAnimTbl
     .byte EnAnim_48 - EnAnimTbl, EnAnim_48 - EnAnimTbl ; unused enemy
     .byte EnAnim_54 - EnAnimTbl, EnAnim_52 - EnAnimTbl
     .byte EnAnim_67 - EnAnimTbl, EnAnim_6A - EnAnimTbl
@@ -202,7 +202,7 @@ EnemyActiveAnimIndex:
     .byte EnAnim_17 - EnAnimTbl, EnAnim_13 - EnAnimTbl ; unused enemy
     .byte EnAnim_1B - EnAnimTbl, EnAnim_19 - EnAnimTbl
     .byte EnAnim_23 - EnAnimTbl, EnAnim_23 - EnAnimTbl
-    .byte EnAnim_35 - EnAnimTbl, EnAnim_35 - EnAnimTbl
+    .byte EnAnim_ZeelaOnFloor - EnAnimTbl, EnAnim_ZeelaOnFloor - EnAnimTbl
     .byte EnAnim_48 - EnAnimTbl, EnAnim_48 - EnAnimTbl ; unused enemy
     .byte EnAnim_4B - EnAnimTbl, EnAnim_48 - EnAnimTbl
     .byte EnAnim_67 - EnAnimTbl, EnAnim_6A - EnAnimTbl

--- a/SRC/prg5_ridley.asm
+++ b/SRC/prg5_ridley.asm
@@ -133,7 +133,7 @@ AreaPalToggle:
 
     .byte $00
 AreaFireballAnimIndex:
-    .byte EnAnim_03 - EnAnimTbl
+    .byte EnAnim_FireballKilled - EnAnimTbl
 AreaExplosionAnimIndex:
     .byte EnAnim_58 - EnAnimTbl
 

--- a/SRC/ridley/enemy_sprite_data.asm
+++ b/SRC/ridley/enemy_sprite_data.asm
@@ -4,7 +4,7 @@ EnAnimTbl: ;($9B85)
 EnAnim_00:
     .byte _id_EnFrame00, _id_EnFrame01, $FF
 
-EnAnim_03:
+EnAnim_FireballKilled:
     .byte _id_EnFrame02, $FF
 
 EnAnim_05:
@@ -65,13 +65,17 @@ EnAnim_3E:
     .byte _id_EnFrame30, _id_EnFrame31, $FF
 
 EnAnim_41:
-    .byte _id_EnFrame31, _id_EnFrame32, $FF
+    .byte _id_EnFrame31
+EnAnim_42:
+    .byte _id_EnFrame32, $FF
 
 EnAnim_44:
     .byte _id_EnFrame33, _id_EnFrame34, $FF
 
 EnAnim_47:
-    .byte _id_EnFrame34, _id_EnFrame35, $FF
+    .byte _id_EnFrame34
+EnAnim_48:
+    .byte _id_EnFrame35, $FF
 
 EnAnim_4A:
     .byte _id_EnFrame58, _id_EnFrame59, $FF

--- a/SRC/tourian/enemy_sprite_data.asm
+++ b/SRC/tourian/enemy_sprite_data.asm
@@ -4,7 +4,7 @@ EnAnimTbl: ;($A406)
 EnAnim_00:
     .byte _id_EnFrame00, _id_EnFrame01, $FF
 
-EnAnim_03:
+EnAnim_FireballKilled:
     .byte _id_EnFrame02, $FF
 
 EnAnim_05:


### PR DESCRIPTION
I used this script to turn enemy frames into PNGs: https://github.com/H-A-M-G-E-R/tools/blob/main/metasprites_2_png.py