### PR TITLE
Fix in UpdateBullet_CollisionWithMotherBrain

### DIFF
--- a/SRC/prg3_tourian.asm
+++ b/SRC/prg3_tourian.asm
@@ -1603,7 +1603,7 @@ UpdateBullet_CollisionWithMotherBrain:
     ldx PageIndex
     ; exit if projectile status is not #$0B (missile?)
     lda ProjectileStatus,x
-    cmp #$0B
+    cmp #wa_Missile
     bne @exit
     ; exit if tile id < $5E
     cpy #$5E


### PR DESCRIPTION
I was testing my port of Junkoid to this disassembly but Asmodeus was immune to baseballs because I shifted the projectile actions...